### PR TITLE
Remove unnecessary vendor prefixes

### DIFF
--- a/kite.scss
+++ b/kite.scss
@@ -35,8 +35,6 @@ If you need to fix this bug, use the following code.
 */
 
 .kite__item {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   display: inline-block;
   font-size: medium; // 3

--- a/kite.styl
+++ b/kite.styl
@@ -35,8 +35,6 @@ If you need to fix this bug, use the following code.
 */
 
 .kite__item {
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   display: inline-block;
   font-size: medium; // 3


### PR DESCRIPTION
maybe, `box-sizing` prefix is no longer needed.

https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
