### PR TITLE
Fix typo: “pagenation” to “pagination”

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,11 +472,11 @@
       </div>
 
       <div class="p-example__item kite__item is-12of12">
-        <h3 class="p-example__title"><span>Pagenation</span></h3>
-        <div class="p-example__result is-x-pagenation u-mbm js-example">
-          <ul class="x-pagenation kite kite--center">
+        <h3 class="p-example__title"><span>Pagination</span></h3>
+        <div class="p-example__result is-x-pagination u-mbm js-example">
+          <ul class="x-pagination kite kite--center">
             <li class="kite__item">
-              <a href="#" class="x-pagenation__prev"><i class="c-ico entypo-left-open"></i></a>
+              <a href="#" class="x-pagination__prev"><i class="c-ico entypo-left-open"></i></a>
             </li>
             <li class="kite__item">
               <a href="#">1</a>
@@ -494,14 +494,14 @@
               <a href="#">30</a>
             </li>
             <li class="kite__item">
-              <a href="#" class="x-pagenation__next"><i class="c-ico entypo-right-open"></i></a>
+              <a href="#" class="x-pagination__next"><i class="c-ico entypo-right-open"></i></a>
             </li>
           </ul>
         </div>
         <div class="p-example__code">
-          <pre><code class="language-markup">&lt;ul class=&quot;x-pagenation kite kite--center&quot;&gt;
+          <pre><code class="language-markup">&lt;ul class=&quot;x-pagination kite kite--center&quot;&gt;
   &lt;li class=&quot;kite__item&quot;&gt;
-    &lt;a href=&quot;#&quot; class=&quot;x-pagenation__prev&quot;&gt;&lt;i class=&quot;c-ico entypo-left-open&quot;&gt;&lt;/i&gt;&lt;/a&gt;
+    &lt;a href=&quot;#&quot; class=&quot;x-pagination__prev&quot;&gt;&lt;i class=&quot;c-ico entypo-left-open&quot;&gt;&lt;/i&gt;&lt;/a&gt;
   &lt;/li&gt;
   &lt;li class=&quot;kite__item&quot;&gt;
     &lt;a href=&quot;#&quot;&gt;1&lt;/a&gt;
@@ -519,7 +519,7 @@
     &lt;a href=&quot;#&quot;&gt;30&lt;/a&gt;
   &lt;/li&gt;
   &lt;li class=&quot;kite__item&quot;&gt;
-    &lt;a href=&quot;#&quot; class=&quot;x-pagenation__next&quot;&gt;&lt;i class=&quot;c-ico entypo-right-open&quot;&gt;&lt;/i&gt;&lt;/a&gt;
+    &lt;a href=&quot;#&quot; class=&quot;x-pagination__next&quot;&gt;&lt;i class=&quot;c-ico entypo-right-open&quot;&gt;&lt;/i&gt;&lt;/a&gt;
   &lt;/li&gt;
 &lt;/ul&gt;</code></pre>
         </div>

--- a/styles/_object.scss
+++ b/styles/_object.scss
@@ -278,10 +278,10 @@
 .p-example__result {
   border-radius: 3px;
   background-color: $matColor;
-  &.is-x-pagenation {
+  &.is-x-pagination {
     padding: 24px 0;
     background-color: #E74C3C;
-    .x-pagenation {
+    .x-pagination {
       a,span {
         display: block;
         border-left: 1px solid rgba(255,255,255,0.5);
@@ -308,10 +308,10 @@
         }
       }
     }
-    .x-pagenation__prev {
+    .x-pagination__prev {
       border-radius: 100% 0 0 100%;
     }
-    .x-pagenation__next {
+    .x-pagination__next {
       border-radius: 0 100% 100% 0;
     }
   }

--- a/styles/main.css
+++ b/styles/main.css
@@ -277,10 +277,10 @@ code {
 .p-example__result {
   border-radius: 3px;
   background-color: #e8f8f5; }
-  .p-example__result.is-x-pagenation {
+  .p-example__result.is-x-pagination {
     padding: 24px 0;
     background-color: #E74C3C; }
-    .p-example__result.is-x-pagenation .x-pagenation a, .p-example__result.is-x-pagenation .x-pagenation span {
+    .p-example__result.is-x-pagination .x-pagination a, .p-example__result.is-x-pagination .x-pagination span {
       display: block;
       border-left: 1px solid rgba(255, 255, 255, 0.5);
       border-right: 1px solid rgba(230, 200, 180, 0.5);
@@ -294,18 +294,18 @@ code {
       color: inherit;
       text-decoration: none;
       text-align: center; }
-      .p-example__result.is-x-pagenation .x-pagenation a > .c-ico, .p-example__result.is-x-pagenation .x-pagenation span > .c-ico {
+      .p-example__result.is-x-pagination .x-pagination a > .c-ico, .p-example__result.is-x-pagination .x-pagination span > .c-ico {
         vertical-align: bottom; }
-      .p-example__result.is-x-pagenation .x-pagenation a:hover, .p-example__result.is-x-pagenation .x-pagenation span:hover {
+      .p-example__result.is-x-pagination .x-pagination a:hover, .p-example__result.is-x-pagination .x-pagination span:hover {
         background: -webkit-linear-gradient(top, #FFFFFF 0%, #FFFFFE 100%);
         background: linear-gradient(to bottom, #FFFFFF 0%, #FFFFFE 100%); }
-      .p-example__result.is-x-pagenation .x-pagenation a:active, .p-example__result.is-x-pagenation .x-pagenation span:active {
+      .p-example__result.is-x-pagination .x-pagination a:active, .p-example__result.is-x-pagination .x-pagination span:active {
         position: relative;
         top: 1px;
         box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.25); }
-    .p-example__result.is-x-pagenation .x-pagenation__prev {
+    .p-example__result.is-x-pagination .x-pagination__prev {
       border-radius: 100% 0 0 100%; }
-    .p-example__result.is-x-pagenation .x-pagenation__next {
+    .p-example__result.is-x-pagination .x-pagination__next {
       border-radius: 0 100% 100% 0; }
   .p-example__result.is-x-media {
     padding: 24px 0;


### PR DESCRIPTION
Just correcting the spelling of `pagenation` in the GitHub Pages branch (in both visible text and class names).